### PR TITLE
Updated toSimple to support data arrays for non-linked requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ exports.toSimple = function (jsonApiData) {
   }
 
   var simpleData = {};
-
+  var tmpArray = [];
   if (jsonApiData.hasOwnProperty('linked')) {
-    var tmpArray;
+    
     if (!Array.isArray(jsonApiData.data)) {
       tmpArray = [jsonApiData.data];
     } else {
@@ -42,7 +42,14 @@ exports.toSimple = function (jsonApiData) {
       simpleData[resourceItem.type].push(convertResource(resourceItem));
     });
   } else {
-    simpleData = convertResource(jsonApiData.data);
+    if (Array.isArray(jsonApiData.data)) {
+		  jsonApiData.data.forEach(function (resourceItem) {
+        tmpArray.push(convertResource(resourceItem));
+      });
+      simpleData = tmpArray;
+	  } else {
+      simpleData = convertResource(jsonApiData.data);
+    }
   }
   return simpleData;
 };


### PR DESCRIPTION
The data object can be an array even when there are no linked objects. I added some code to support this. 